### PR TITLE
Fix 'trans not defined'

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def close(issue, tid):
 
 @jira_request_time_reopen.time()
 def reopen(issue, tid):
-    return jira.transition_issue(issue, trans['reopen'])
+    return jira.transition_issue(issue, tid)
 
 @jira_request_time_update.time()
 def update_issue(issue, summary, description):


### PR DESCRIPTION
Without this change, `trans` is found to be undefined and issues fail to be reopened.