### PR TITLE
Add a dockerfile for easy deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.6.2-alpine
+
+RUN mkdir -p /opt/jiraalerts
+
+# A valid Jira user
+ENV "JIRA_USERNAME" ""
+
+# That users password
+ENV "JIRA_PASSWORD" ""
+
+# The full address to the jira server (including the https:// bit)
+ENV "JIRA_SERVER" ""
+
+ADD main.py requirements.txt /opt/jiraalerts/
+
+RUN export BUILD_PKGS="build-base musl-dev linux-headers" && \ 
+    export RUN_PKGS="tini" && \
+        apk add --no-cache ${BUILD_PKGS} ${RUN_PKGS} && \
+    pip install --requirement /opt/jiraalerts/requirements.txt && \
+    apk del ${BUILD_PKGS}
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+# Allow the use of environment variables in the CMD. 
+# See https://github.com/moby/moby/issues/5509
+CMD ["sh", "-c", "python /opt/jiraalerts/main.py $JIRA_SERVER"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ ENTRYPOINT ["/sbin/tini", "--"]
 
 # Allow the use of environment variables in the CMD. 
 # See https://github.com/moby/moby/issues/5509
-CMD ["sh", "-c", "python /opt/jiraalerts/main.py $JIRA_SERVER"]
+CMD ["sh", "-c", "python /opt/jiraalerts/main.py --host='0.0.0.0' $JIRA_SERVER"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6.2-alpine
 
-RUN mkdir -p /opt/jiraalerts
+RUN mkdir -p /opt/jiralerts
 
 # A valid Jira user
 ENV "JIRA_USERNAME" ""
@@ -11,17 +11,19 @@ ENV "JIRA_PASSWORD" ""
 # The full address to the jira server (including the https:// bit)
 ENV "JIRA_SERVER" ""
 
-ADD main.py requirements.txt /opt/jiraalerts/
+ADD requirements.txt /opt/jiralerts/
 
 RUN export BUILD_PKGS="build-base musl-dev linux-headers" && \ 
     export RUN_PKGS="tini" && \
         apk add --no-cache ${BUILD_PKGS} ${RUN_PKGS} && \
-    pip install --requirement /opt/jiraalerts/requirements.txt && \
+    pip install --requirement /opt/jiralerts/requirements.txt && \
     apk del ${BUILD_PKGS}
+
+ADD main.py /opt/jiralerts/
 
 ENTRYPOINT ["/sbin/tini", "--"]
 
 # Allow the use of environment variables in the CMD. 
 # See https://github.com/moby/moby/issues/5509
-CMD ["sh", "-c", "python /opt/jiraalerts/main.py --host='0.0.0.0' $JIRA_SERVER"]
+CMD ["sh", "-c", "python /opt/jiralerts/main.py --host='0.0.0.0' $JIRA_SERVER"]
 


### PR DESCRIPTION
Previously, this application was setup such that it must be installed
in whatever environment it must operate in. While this is reasonable in
cases where the infrastructure is controlled, in infrastructure that is
more dynamic it is difficult to decide where to place this application.

The tool 'Docker' allows packing and deploying the application in a
single, addressable unit (usually in the authors experience to
Kubernetes) such that it can be quickly spun up for usage.

Design Notes:

tini:

  A small init system is included in the container. Normally, the
  problem with running processes in a docker container is they might
  spawn further processes. When the parent process dies, the child
  process should be "reparented" to 1 for reaping. However, in
  containers without a valid init system, this reaping does not occur.
  Tini is a small system to do this.

  This program is a simple python script, that does not appear to spawn
  new processes. However, it is the authors habit to universally apply
  the same init tree to all docker containers, as it is simpler than
  determining in each case whether the reaping is likely to be a
  problem.

sh:

  As mentioned in the patch comments, docker does not allow variable
  interpolation in cmd. Thus, shell is used as an invoking process,
  which does.

  This creates a slightly longer process tree, but the author is
  of the opinion that this does no harm. Further, even though shell must
  now be involved in the mix, the author does not believe that it will
  reap correctly, and thus cannot be used as init.