### PR TITLE
Correct path in README for the issues endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In your Alertmanager receiver configurations:
 receivers:
 - name: 'jira_issues'
   webhook_configs:
-  - url: 'http://<jira_address>/<jira_project>/<single_label>'
+  - url: 'http://<jiralerts_address>/issues/<jira_project>/<team>'
 ```
 
 A typical usage could be a single 'ALERTS' projects where the label in the URL


### PR DESCRIPTION
In attempting to consume the script, the author configured the
AlertMangager naively as indicated in the documentation. However, this
did not work as anticipated -- the script returned a 404 to this
endpoint.

Further static analysis of the main.py file indicates that the URL in
the readme is not correct. It was configured as this patch indicates,
and appears to be responding as anticipated

This was not completely tested, as the author is reconciling other bugs
in other streams of work.