### PR TITLE
Make the initial task configurable

### DIFF
--- a/jiralerts.ini
+++ b/jiralerts.ini
@@ -1,7 +1,7 @@
-# This is the Jiralerts configuration file. It serves as both default values, and a heavily annotated example
-# configuration
+## This is the Jiralerts configuration file. It serves as both default values, and a heavily annotated example
+## configuration
 
 [jira]
 
-# The issue type that will be created when an alert arrives. Must exist in the Jira project.
-issue_type = 'Task'
+## The issue type that will be created when an alert arrives. Must exist in the Jira project.
+## issue_type = Task

--- a/jiralerts.ini
+++ b/jiralerts.ini
@@ -1,0 +1,7 @@
+# This is the Jiralerts configuration file. It serves as both default values, and a heavily annotated example
+# configuration
+
+[jira]
+
+# The issue type that will be created when an alert arrives. Must exist in the Jira project.
+issue_type = 'Task'

--- a/main.py
+++ b/main.py
@@ -2,8 +2,10 @@
 
 import os
 import sys
+import configparser
 
 import click
+
 from flask import Flask, request, make_response
 from jira import JIRA
 from jinja2 import Template
@@ -12,6 +14,10 @@ import prometheus_client as prometheus
 app = Flask(__name__)
 
 jira = None
+
+# Setup the configuration
+config = configparser.ConfigParser()
+config.read('jiralerts.ini')
 
 summary_tmpl = Template(r'{% if commonAnnotations.summary %}{{ commonAnnotations.summary }}{% else %}{% for k, v in groupLabels.items() %}{{ k }}="{{v}}" {% endfor %}{% endif %}')
 
@@ -81,7 +87,7 @@ def create_issue(project, team, summary, description):
         'project': {'key': project},
         'summary': summary,
         'description': "%s\n\n%s" % (description_boundary, description),
-        'issuetype': {'name': 'Task'},
+        'issuetype': {'name': config['jira']['issue_type']},
         'labels': ['alert', team],
     })
 

--- a/main.py
+++ b/main.py
@@ -19,6 +19,11 @@ jira = None
 config = configparser.ConfigParser()
 config.read('jiralerts.ini')
 
+if not config.has_section('jira'):
+    config['jira'] = {}
+
+jira_config = config['jira']
+
 summary_tmpl = Template(r'{% if commonAnnotations.summary %}{{ commonAnnotations.summary }}{% else %}{% for k, v in groupLabels.items() %}{{ k }}="{{v}}" {% endfor %}{% endif %}')
 
 description_tmpl = Template(r'''
@@ -87,7 +92,7 @@ def create_issue(project, team, summary, description):
         'project': {'key': project},
         'summary': summary,
         'description': "%s\n\n%s" % (description_boundary, description),
-        'issuetype': {'name': config['jira']['issue_type']},
+        'issuetype': {'name': jira_config.get('issue_type', 'Task')},
         'labels': ['alert', team],
     })
 


### PR DESCRIPTION
Currently, when an alert arrives a new task of the type "Task" is
created. However, this type does not always exist in projects; in the
authors example, the types:

  - "Bug"
  - "Story"
  - "Epic"

exist, but the type "Task" does not. This commit makes the initial task
configurable, but leaves the default value of "Task"

Design Notes:

configparser:

  The configuration format specified by the "configparser" python stdlib
  is used for configuration. This was used as the author has very
  limited experience with python, but presumes the configparser is the
  most common way of expressing configuration.

  Future work might consider merging command line variables into this
  ini format.