### PR TITLE
Make compatible with the newer syntax used by the alert manager

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from flask import Flask, request, make_response
 from jira import JIRA
 from jinja2 import Template
 import prometheus_client as prometheus
+import base64
 
 app = Flask(__name__)
 
@@ -39,6 +40,7 @@ _Labels_:
 
 
 alert_group_key={{ groupKey }}
+jiraReference={{ jira_reference }}
 ''')
 
 description_boundary = '_-- Alertmanager -- [only edit above]_'
@@ -93,19 +95,25 @@ def health():
 @app.route('/issues/<project>/<team>', methods=['POST'])
 def file_issue(project, team):
     """
-    This endpoint accepts a JSON encoded notification according to the version 3
+    This endpoint accepts a JSON encoded notification according to the version 3 or 4
     of the generic webhook of the Prometheus Alertmanager.
     """
     data = request.get_json()
-    if data['version'] != "3":
+    if data['version'] not in ["3", "4"]:
         return "unknown message version %s" % data['version'], 400
 
     resolved = data['status'] == "resolved"
+
+    # In python 3, base64 must be passed a byte array. However, the supplied argument is
+    # a string, unencoded. Thus, it must be converted to an encoded string, base64 encoded, and decoded again
+    # for use by jinja
+    data['jiraReference'] = base64.b64encode(data['groupKey'].encode('utf-8')).decode('utf-8')
+
     description = description_tmpl.render(data)
     summary = summary_tmpl.render(data)
 
     # If there's already a ticket for the incident, update it and reopen/close if necessary.
-    result = jira.search_issues(search_query % (project, data['groupKey']))
+    result = jira.search_issues(search_query % (project, data['jiraReference']))
     if result:
         issue = result[0]
 


### PR DESCRIPTION
Recently, changes were made to the alert manager output such that

1. The version is now "4"
2. The "group key" is now a string, of arbitrary characters

Previously, the group key was number, and could be supplied to
Jira in the form of JQL without any escaping. However, now that it is a
string, it includes characters such as the "{}" character or spaces that
have special meaning within JQL.

Group key is still a good candidate for matching tickets. Thus, it has
been base64 encoded and that is used as the matching key. This does not
lose any semantic information (at least, it can be reversed) but is
compatible with JQL now and going forward.

BREAKING CHANGE:

This will break matching for any existing tickets that are using
the numeric ticket reference to keep track.